### PR TITLE
WIP: Feature/ad development

### DIFF
--- a/src/c/analyses/StressbalanceAnalysis.cpp
+++ b/src/c/analyses/StressbalanceAnalysis.cpp
@@ -1527,19 +1527,20 @@ ElementMatrix* StressbalanceAnalysis::CreateKMatrixSSAViscous(Element* element){
 		thickness_input->GetInputValue(&thickness, gauss);
 		element->material->ViscositySSA(&viscosity,dim,xyz_list,gauss,vx_input,vy_input);
 
+		IssmDouble factor = gauss->weight*Jdet*viscosity*thickness;
 		if(dim==2){
 			for(int i=0;i<numnodes;i++){
 				for(int j=0;j<numnodes;j++){
-					Ke->values[2*i*2*numnodes+2*j] += gauss->weight*Jdet*viscosity*thickness*(
+					Ke->values[2*i*2*numnodes+2*j] += factor*(
 								4.*dbasis[0*numnodes+j]*dbasis[0*numnodes+i] + dbasis[1*numnodes+j]*dbasis[1*numnodes+i]
 								);
-					Ke->values[2*i*2*numnodes+2*j+1] += gauss->weight*Jdet*viscosity*thickness*(
+					Ke->values[2*i*2*numnodes+2*j+1] += factor*(
 								2.*dbasis[1*numnodes+j]*dbasis[0*numnodes+i] + dbasis[0*numnodes+j]*dbasis[1*numnodes+i]
 								);
-					Ke->values[(2*i+1)*2*numnodes+2*j] += gauss->weight*Jdet*viscosity*thickness*(
+					Ke->values[(2*i+1)*2*numnodes+2*j] += factor*(
 								2.*dbasis[0*numnodes+j]*dbasis[1*numnodes+i] + dbasis[1*numnodes+j]*dbasis[0*numnodes+i]
 								);
-					Ke->values[(2*i+1)*2*numnodes+2*j+1] += gauss->weight*Jdet*viscosity*thickness*(
+					Ke->values[(2*i+1)*2*numnodes+2*j+1] += factor*(
 								dbasis[0*numnodes+j]*dbasis[0*numnodes+i] + 4.*dbasis[1*numnodes+j]*dbasis[1*numnodes+i]
 								);
 				}
@@ -1548,7 +1549,7 @@ ElementMatrix* StressbalanceAnalysis::CreateKMatrixSSAViscous(Element* element){
 		else{
 			for(int i=0;i<numnodes;i++){
 				for(int j=0;j<numnodes;j++){
-					Ke->values[i*numnodes+j] += gauss->weight*Jdet*viscosity*thickness*(
+					Ke->values[i*numnodes+j] += factor*(
 								4.*dbasis[0*numnodes+j]*dbasis[0*numnodes+i]
 								);
 				}

--- a/src/c/toolkits/codipack/CoDiPackTypes.h
+++ b/src/c/toolkits/codipack/CoDiPackTypes.h
@@ -11,7 +11,11 @@
 
 #include <codi.hpp>
 
-using CoDiReal = codi::RealReverse;
+#ifndef CODIPACK_TYPE
+#define CODIPACK_TYPE codi::RealReverse
+#endif
+
+using CoDiReal = CODIPACK_TYPE;
 
 #endif /* _HAVE_CODIPACK_ */
 #endif /* SRC_C_TOOLKITS_CODIPACK_CODIPACKTYPES_H_ */

--- a/src/c/toolkits/issm/SparseRow.h
+++ b/src/c/toolkits/issm/SparseRow.h
@@ -65,6 +65,15 @@ class SparseRow{
 			/*check numvalues: */
 			if(!numvalues)return;
 
+#if _HAVE_CODIPACK_
+			codi::PreaccumulationHelper<IssmDouble> ph{};
+
+			ph.start();
+			for(i=0; i < numvalues; i += 1) {
+				ph.addInput(vals[i]);
+			}
+#endif
+
 			/*Go through cols and resolve duplicates: */
 			for(i=0;i<numvalues;i++){
 				for(j=i+1;j<numvalues;j++){
@@ -95,6 +104,13 @@ class SparseRow{
 					count++;
 				}
 			}
+
+#if _HAVE_CODIPACK_
+			for(i = 0; i < ncols; i += 1) {
+				ph.addOutput(values[i]);
+			}
+			ph.finish(false);
+#endif
 
 			if(count!=ncols)_error_("counter problem during set values operations");
 		} /*}}}*/


### PR DESCRIPTION
Further additions for AD.

 - The prepocessor option -DCODIPACK_TYPE can be used to change the CoDiPack type used in ISSM codi::RealReverseIndex seems to work but needs to be further tested.
 - Improvement in StressbalanceAnalysis for AD to avoid recomputation of a common expression. (The compiler should be able to optimize this for the primal, but it will probably also help here.)
 - Adds CoDiPack Preaccumulation in SparseRow. This change needs to be tested and evaluated for changes in the timing of the AD computations.