### PR TITLE
Fix NaN in mass flux computation

### DIFF
--- a/src/c/Makefile.am
+++ b/src/c/Makefile.am
@@ -165,6 +165,7 @@ issm_sources += \
 	./shared/Numerics/extrema.cpp \
 	./shared/Numerics/legendre.cpp \
 	./shared/Numerics/XZvectorsToCoordinateSystem.cpp \
+	./shared/Numerics/Normals.cpp \
 	./shared/Exceptions/Exceptions.cpp \
 	./shared/Sorting/binary_search.cpp \
 	./shared/Elements/Cuffey.cpp \

--- a/src/c/classes/Elements/Penta.cpp
+++ b/src/c/classes/Elements/Penta.cpp
@@ -3164,82 +3164,22 @@ int        Penta::NodalValue(IssmDouble* pvalue, int index, int natureofdataenum
 }
 /*}}}*/
 void       Penta::NormalBase(IssmDouble* bed_normal,IssmDouble* xyz_list){/*{{{*/
-
-	IssmDouble v13[3],v23[3];
-	IssmDouble normal[3];
-	IssmDouble normal_norm;
-
-	for(int i=0;i<3;i++){
-		v13[i]=xyz_list[0*3+i]-xyz_list[2*3+i];
-		v23[i]=xyz_list[1*3+i]-xyz_list[2*3+i];
-	}
-
-	normal[0]=v13[1]*v23[2]-v13[2]*v23[1];
-	normal[1]=v13[2]*v23[0]-v13[0]*v23[2];
-	normal[2]=v13[0]*v23[1]-v13[1]*v23[0];
-	normal_norm=sqrt(normal[0]*normal[0]+ normal[1]*normal[1]+ normal[2]*normal[2]);
-
+	TriangleFacetNormal(bed_normal, xyz_list);
 	/*Bed normal is opposite to surface normal*/
-	bed_normal[0]=-normal[0]/normal_norm;
-	bed_normal[1]=-normal[1]/normal_norm;
-	bed_normal[2]=-normal[2]/normal_norm;
+	for (int i = 0; i < 3; ++i) bed_normal[i] *= (-1);
 }
 /*}}}*/
 void       Penta::NormalSection(IssmDouble* normal,IssmDouble* xyz_list){/*{{{*/
 
-	/*Build unit outward pointing vector*/
-	IssmDouble AB[3];
-	IssmDouble AC[3];
-	IssmDouble norm;
-
-	AB[0]=xyz_list[1*3+0] - xyz_list[0*3+0];
-	AB[1]=xyz_list[1*3+1] - xyz_list[0*3+1];
-	AB[2]=xyz_list[1*3+2] - xyz_list[0*3+2];
-	AC[0]=xyz_list[2*3+0] - xyz_list[0*3+0];
-	AC[1]=xyz_list[2*3+1] - xyz_list[0*3+1];
-	AC[2]=xyz_list[2*3+2] - xyz_list[0*3+2];
-
-	cross(normal,AB,AC);
-	norm=sqrt(normal[0]*normal[0]+normal[1]*normal[1]+normal[2]*normal[2]);
-
-	for(int i=0;i<3;i++) normal[i]=normal[i]/(norm+1e-10);
+	TriangleFacetNormal(normal, xyz_list);
 }
 /*}}}*/
 void       Penta::NormalSectionBase(IssmDouble* normal,IssmDouble* xyz_list){/*{{{*/
-
-	/*Build unit outward pointing vector*/
-	IssmDouble vector[2];
-	IssmDouble norm;
-
-	vector[0]=xyz_list[1*3+0] - xyz_list[0*3+0];
-	vector[1]=xyz_list[1*3+1] - xyz_list[0*3+1];
-
-	norm=sqrt(vector[0]*vector[0] + vector[1]*vector[1]);
-
-	normal[0]= + vector[1]/norm;
-	normal[1]= - vector[0]/norm;
+	LineSectionNormal(normal, xyz_list);
 }
 /*}}}*/
 void       Penta::NormalTop(IssmDouble* top_normal,IssmDouble* xyz_list){/*{{{*/
-
-	int i;
-	IssmDouble v13[3],v23[3];
-	IssmDouble normal[3];
-	IssmDouble normal_norm;
-
-	for (i=0;i<3;i++){
-		v13[i]=xyz_list[0*3+i]-xyz_list[2*3+i];
-		v23[i]=xyz_list[1*3+i]-xyz_list[2*3+i];
-	}
-
-	normal[0]=v13[1]*v23[2]-v13[2]*v23[1];
-	normal[1]=v13[2]*v23[0]-v13[0]*v23[2];
-	normal[2]=v13[0]*v23[1]-v13[1]*v23[0];
-	normal_norm=sqrt(normal[0]*normal[0] + normal[1]*normal[1] + normal[2]*normal[2]);
-
-	top_normal[0]=normal[0]/normal_norm;
-	top_normal[1]=normal[1]/normal_norm;
-	top_normal[2]=normal[2]/normal_norm;
+	TriangleFacetNormal(top_normal, xyz_list);
 }
 /*}}}*/
 int        Penta::NumberofNodesPressure(void){/*{{{*/

--- a/src/c/classes/Elements/Tetra.cpp
+++ b/src/c/classes/Elements/Tetra.cpp
@@ -564,68 +564,19 @@ void     Tetra::NodalFunctionsVelocity(IssmDouble* basis, Gauss* gauss){/*{{{*/
 }
 /*}}}*/
 void     Tetra::NormalBase(IssmDouble* bed_normal,IssmDouble* xyz_list){/*{{{*/
-
-	IssmDouble v13[3],v23[3];
-	IssmDouble normal[3];
-	IssmDouble normal_norm;
-
-	for(int i=0;i<3;i++){
-		v13[i]=xyz_list[0*3+i]-xyz_list[2*3+i];
-		v23[i]=xyz_list[1*3+i]-xyz_list[2*3+i];
-	}
-
-	normal[0]=v13[1]*v23[2]-v13[2]*v23[1];
-	normal[1]=v13[2]*v23[0]-v13[0]*v23[2];
-	normal[2]=v13[0]*v23[1]-v13[1]*v23[0];
-	normal_norm=sqrt(normal[0]*normal[0]+ normal[1]*normal[1]+ normal[2]*normal[2]);
-
-	/*Bed normal is opposite to surface normal*/
-	bed_normal[0]=-normal[0]/normal_norm;
-	bed_normal[1]=-normal[1]/normal_norm;
-	bed_normal[2]=-normal[2]/normal_norm;
-
+	TriangleFacetNormal(bed_normal, xyz_list);
 	_assert_(bed_normal[2]<0.);
+	
+	/*Bed normal is opposite to surface normal*/
+	for (int i = 0; i < 3; ++i) bed_normal[i] *= (-1);
 }
 /*}}}*/
 void     Tetra::NormalSection(IssmDouble* normal,IssmDouble* xyz_list){/*{{{*/
-
-	/*Build unit outward pointing vector*/
-	IssmDouble AB[3];
-	IssmDouble AC[3];
-	IssmDouble norm;
-
-	AB[0]=xyz_list[1*3+0] - xyz_list[0*3+0];
-	AB[1]=xyz_list[1*3+1] - xyz_list[0*3+1];
-	AB[2]=xyz_list[1*3+2] - xyz_list[0*3+2];
-	AC[0]=xyz_list[2*3+0] - xyz_list[0*3+0];
-	AC[1]=xyz_list[2*3+1] - xyz_list[0*3+1];
-	AC[2]=xyz_list[2*3+2] - xyz_list[0*3+2];
-
-	cross(normal,AB,AC);
-	norm=sqrt(normal[0]*normal[0]+normal[1]*normal[1]+normal[2]*normal[2]);
-
-	for(int i=0;i<3;i++) normal[i]=normal[i]/(norm+1e-10);
+	TriangleFacetNormal(normal, xyz_list);
 }
 /*}}}*/
 void     Tetra::NormalTop(IssmDouble* top_normal,IssmDouble* xyz_list){/*{{{*/
-
-	IssmDouble v13[3],v23[3];
-	IssmDouble normal[3];
-	IssmDouble normal_norm;
-
-	for(int i=0;i<3;i++){
-		v13[i]=xyz_list[0*3+i]-xyz_list[2*3+i];
-		v23[i]=xyz_list[1*3+i]-xyz_list[2*3+i];
-	}
-
-	normal[0]=v13[1]*v23[2]-v13[2]*v23[1];
-	normal[1]=v13[2]*v23[0]-v13[0]*v23[2];
-	normal[2]=v13[0]*v23[1]-v13[1]*v23[0];
-	normal_norm=sqrt(normal[0]*normal[0]+ normal[1]*normal[1]+ normal[2]*normal[2]);
-
-	top_normal[0]=normal[0]/normal_norm;
-	top_normal[1]=normal[1]/normal_norm;
-	top_normal[2]=normal[2]/normal_norm;
+	TriangleFacetNormal(top_normal, xyz_list);
 	_assert_(top_normal[2]>0.);
 }
 /*}}}*/

--- a/src/c/classes/Elements/Tria.cpp
+++ b/src/c/classes/Elements/Tria.cpp
@@ -4957,51 +4957,20 @@ int        Tria::NodalValue(IssmDouble* pvalue, int index, int natureofdataenum)
 }
 /*}}}*/
 void       Tria::NormalBase(IssmDouble* bed_normal,IssmDouble* xyz_list){/*{{{*/
-
-	/*Build unit outward pointing vector*/
-	IssmDouble vector[2];
-	IssmDouble norm;
-
-	vector[0]=xyz_list[1*3+0] - xyz_list[0*3+0];
-	vector[1]=xyz_list[1*3+1] - xyz_list[0*3+1];
-
-	norm=sqrt(vector[0]*vector[0] + vector[1]*vector[1]);
-
-	bed_normal[0]= + vector[1]/norm;
-	bed_normal[1]= - vector[0]/norm;
+	LineSectionNormal(bed_normal, xyz_list);
 	_assert_(bed_normal[1]<0);
 }
 /*}}}*/
 void       Tria::NormalSection(IssmDouble* normal,IssmDouble* xyz_list){/*{{{*/
-
-	/*Build unit outward pointing vector*/
-	IssmDouble vector[2];
-	IssmDouble norm;
-
-	vector[0]=xyz_list[1*3+0] - xyz_list[0*3+0];
-	vector[1]=xyz_list[1*3+1] - xyz_list[0*3+1];
-
-	norm=sqrt(vector[0]*vector[0] + vector[1]*vector[1]);
-
-	normal[0]= + vector[1]/(norm+1e-10);
-	normal[1]= - vector[0]/(norm+1e-10);
+	LineSectionNormal(normal, xyz_list);
 }
 /*}}}*/
 void       Tria::NormalTop(IssmDouble* top_normal,IssmDouble* xyz_list){/*{{{*/
-
-	/*Build unit outward pointing vector*/
+	//does this do anything?
 	int index1,index2;
-	IssmDouble vector[2];
-	IssmDouble norm;
-
 	this->EdgeOnSurfaceIndices(&index1,&index2);
-	vector[0]=xyz_list[1*3+0] - xyz_list[0*3+0];
-	vector[1]=xyz_list[1*3+1] - xyz_list[0*3+1];
 
-	norm=sqrt(vector[0]*vector[0] + vector[1]*vector[1]);
-
-	top_normal[0]= + vector[1]/norm;
-	top_normal[1]= - vector[0]/norm;
+	LineSectionNormal(top_normal, xyz_list);
 	_assert_(top_normal[1]>0);
 }
 /*}}}*/

--- a/src/c/shared/Numerics/Normals.cpp
+++ b/src/c/shared/Numerics/Normals.cpp
@@ -16,18 +16,18 @@ void LineSectionNormal(IssmDouble* normal, IssmDouble* xyz_list) {
 	vector[0]=xyz_list[1*3+0] - xyz_list[0*3+0];
 	vector[1]=xyz_list[1*3+1] - xyz_list[0*3+1];
 
-    normal[0] = vector[1];
-    normal[1] = -vector[0];
+	normal[0] = vector[1];
+	normal[1] = -vector[0];
 
-    //normalize
+	//normalize
 	IssmDouble norm=sqrt(normal[0]*normal[0] + normal[1]*normal[1]);
-    norm = max(norm, 1e-10); // avoid NaN
-    normal[0] /= norm;
-    normal[1] /= norm;
+	norm = max(norm, 1e-10); // avoid NaN
+	normal[0] /= norm;
+	normal[1] /= norm;
 }
 
 void TriangleFacetNormal(IssmDouble* normal, IssmDouble* xyz_list) {
-    IssmDouble AB[3];
+	IssmDouble AB[3];
 	IssmDouble AC[3];
 
 	AB[0]=xyz_list[1*3+0] - xyz_list[0*3+0];
@@ -38,9 +38,9 @@ void TriangleFacetNormal(IssmDouble* normal, IssmDouble* xyz_list) {
 	AC[2]=xyz_list[2*3+2] - xyz_list[0*3+2];
 
 	cross(normal,AB,AC);
-	
-    //normalize
-    IssmDouble norm=sqrt(normal[0]*normal[0]+normal[1]*normal[1]+normal[2]*normal[2]);
-    norm = max(norm, 1e-10); // avoid NaN
+
+	//normalize
+	IssmDouble norm=sqrt(normal[0]*normal[0]+normal[1]*normal[1]+normal[2]*normal[2]);
+	norm = max(norm, 1e-10); // avoid NaN
 	for(int i=0;i<3;i++) normal[i] /= norm;
 }

--- a/src/c/shared/Numerics/Normals.cpp
+++ b/src/c/shared/Numerics/Normals.cpp
@@ -1,0 +1,46 @@
+/*!\file:  Normals.cpp
+ * \brief Normal vectors for sections.
+ */ 
+
+#ifdef HAVE_CONFIG_H
+	#include <config.h>
+#else
+#error "Cannot compile with HAVE_CONFIG_H symbol! run configure first!"
+#endif
+
+#include "./types.h"
+#include "../shared.h"
+
+void LineSectionNormal(IssmDouble* normal, IssmDouble* xyz_list) {
+	IssmDouble vector[2];
+	vector[0]=xyz_list[1*3+0] - xyz_list[0*3+0];
+	vector[1]=xyz_list[1*3+1] - xyz_list[0*3+1];
+
+    normal[0] = vector[1];
+    normal[1] = -vector[0];
+
+    //normalize
+	IssmDouble norm=sqrt(normal[0]*normal[0] + normal[1]*normal[1]);
+    norm = max(norm, 1e-10); // avoid NaN
+    normal[0] /= norm;
+    normal[1] /= norm;
+}
+
+void TriangleFacetNormal(IssmDouble* normal, IssmDouble* xyz_list) {
+    IssmDouble AB[3];
+	IssmDouble AC[3];
+
+	AB[0]=xyz_list[1*3+0] - xyz_list[0*3+0];
+	AB[1]=xyz_list[1*3+1] - xyz_list[0*3+1];
+	AB[2]=xyz_list[1*3+2] - xyz_list[0*3+2];
+	AC[0]=xyz_list[2*3+0] - xyz_list[0*3+0];
+	AC[1]=xyz_list[2*3+1] - xyz_list[0*3+1];
+	AC[2]=xyz_list[2*3+2] - xyz_list[0*3+2];
+
+	cross(normal,AB,AC);
+	
+    //normalize
+    IssmDouble norm=sqrt(normal[0]*normal[0]+normal[1]*normal[1]+normal[2]*normal[2]);
+    norm = max(norm, 1e-10); // avoid NaN
+	for(int i=0;i<3;i++) normal[i] /= norm;
+}

--- a/src/c/shared/Numerics/numerics.h
+++ b/src/c/shared/Numerics/numerics.h
@@ -42,4 +42,7 @@ IssmDouble*  p_polynomial_value ( int m, int n, IssmDouble* x);
 int         NewtonSolveDnorm(IssmDouble* pdnorm,IssmDouble c1,IssmDouble c2,IssmDouble c3,IssmDouble n,IssmDouble dnorm);
 IssmDouble  ODE1(IssmDouble alpha,IssmDouble beta,IssmDouble Si, IssmDouble dt,int method);
 
+void LineSectionNormal(IssmDouble* result, IssmDouble* xyz_section);
+void TriangleFacetNormal(IssmDouble* normal, IssmDouble* xyz_facet);
+
 #endif //ifndef _NUMERICS_H_


### PR DESCRIPTION
The computation of mass flux (e.g. `IcefrontMassFluxLevelset`) fails for some 3D meshes. If the ice front is very short and very close to one vertex (.e.g. one vertex with a near zero positive level set value and the other vertices larger negative values), the points computed as the endpoints of the ice front section can be identical due to floating point truncation. The normal vector to the ice front is then `NaN` because of division by zero. So the result for one element is then `NaN` as well instead of 0 as expected for a zero length ice front section.

It looks like this problem has been fixed in the past for 2D Tria elements and other computations of normal vectors by setting the norm of the normal vector to some non-zero value. I added this fix to Penta.

To avoid this problem in the future, I felt it would be a good idea to remove some of the duplicate normal vector code. I checked carefully that everything is exactly equivalent, please confirm. I wasn't quite sure about `Tria::NormalBase` and `Tria::NormalTop`, why they compute a normal vector for a line instead of a triangle, but I guess this is for vertical triangle meshes?