### PR TITLE
CHG: Resolve issue: Error in compiling both Matlab and Python. 

### DIFF
--- a/src/wrappers/javascript/Makefile.am
+++ b/src/wrappers/javascript/Makefile.am
@@ -35,12 +35,12 @@ libISSMJavascript_la_SOURCES = $(io_sources)
 libISSMJavascript_la_CXXFLAGS= $(ALLCXXFLAGS)
 #}}}
 # API I/O{{{
-lib_LTLIBRARIES += libISSMApi.la
+lib_LTLIBRARIES += libISSMApi_Java.la
 
 api_sources= ./io/ApiPrintf.cpp
 
-libISSMApi_la_SOURCES = $(api_sources)
-libISSMApi_la_CXXFLAGS= $(ALLCXXFLAGS)
+libISSMApi_Java_la_SOURCES = $(api_sources)
+libISSMApi_Java_la_CXXFLAGS= $(ALLCXXFLAGS)
 #}}}
 # Wrappers {{{
 bin_PROGRAMS = IssmModule
@@ -52,7 +52,7 @@ bin_PROGRAMS = IssmModule
 AM_CXXFLAGS = -DTRILIBRARY -DANSI_DECLARATORS -DNO_TIMER -D_WRAPPERS_
 AM_CXXFLAGS += -D_HAVE_JAVASCRIPT_MODULES_ -fPIC
 
-deps = ./libISSMJavascript.la ../../c/libISSMModules.la ../../c/libISSMCore.la ./libISSMApi.la
+deps = ./libISSMJavascript.la ../../c/libISSMModules.la ../../c/libISSMCore.la ./libISSMApi_Java.la
 
 # Optimization flags
 AM_CXXFLAGS += $(CXXFLAGS)
@@ -62,21 +62,21 @@ libISSMJavascript_la_LIBADD = ./../../c/libISSMCore.la ./../../c/libISSMModules.
 
 if VERSION
 libISSMJavascript_la_LDFLAGS =
-libISSMApi_la_LDFLAGS =
+libISSMApi_Java_la_LDFLAGS =
 else
 libISSMJavascript_la_LDFLAGS = -avoid-version
-libISSMApi_la_LDFLAGS = -avoid-version
+libISSMApi_Java_la_LDFLAGS = -avoid-version
 endif
 
 if STANDALONE_LIBRARIES
 if !MSYS2
 libISSMJavascript_la_LDFLAGS += -static
-libISSMApi_la_LDFLAGS += -static
+libISSMApi_Java_la_LDFLAGS += -static
 endif
 deps += $(DAKOTALIB) $(PETSCLIB) $(MUMPSLIB) $(SCALAPACKLIB) $(BLASLAPACKLIB) $(PARMETISLIB) $(METISLIB) $(HDF5LIB) $(TAOLIB) $(M1QN3LIB) $(SEMICLIB) $(PLAPACKLIB) $(SUPERLULIB) $(SPOOLESLIB) $(TRIANGLELIB) $(BLACSLIB) $(HYPRELIB) $(SPAILIB) $(PROMETHEUSLIB) $(PASTIXLIB) $(MLLIB) $(SCOTCHLIB) $(MKLLIB) $(MPILIB) $(NEOPZLIB) $(MATHLIB) $(GRAPHICSLIB) $(MULTITHREADINGLIB) $(GSLLIB) $(ADOLCLIB) $(AMPILIB) $(METEOIOLIB) $(SNOWPACKLIB) $(PROJLIB) $(OSLIBS)
 endif
 
-libISSMApi_la_LIBADD = $(PETSCLIB) $(MUMPSLIB) $(SCALAPACKLIB) $(BLASLAPACKLIB) $(PARMETISLIB) $(METISLIB) $(HDF5LIB) $(MPILIB) $(NEOPZLIB) $(GSLLIB) $(PROJLIB) $(MATHLIB)
+libISSMApi_Java_la_LIBADD = $(PETSCLIB) $(MUMPSLIB) $(SCALAPACKLIB) $(BLASLAPACKLIB) $(PARMETISLIB) $(METISLIB) $(HDF5LIB) $(MPILIB) $(NEOPZLIB) $(GSLLIB) $(PROJLIB) $(MATHLIB)
 
 IssmModule_SOURCES = \
 	../BamgMesher/BamgMesher.cpp \

--- a/src/wrappers/matlab/Makefile.am
+++ b/src/wrappers/matlab/Makefile.am
@@ -27,13 +27,13 @@ libISSMMatlab_la_SOURCES = $(io_sources)
 libISSMMatlab_la_CXXFLAGS = ${ALL_CXXFLAGS}
 #}}}
 #api io{{{
-lib_LTLIBRARIES += libISSMApi.la
+lib_LTLIBRARIES += libISSMApi_Matlab.la
 
 if !MSYS2
 api_sources= ./io/ApiPrintf.cpp
 
-libISSMApi_la_SOURCES = $(api_sources)
-libISSMApi_la_CXXFLAGS = ${ALL_CXXFLAGS}
+libISSMApi_Matlab_la_SOURCES = $(api_sources)
+libISSMApi_Matlab_la_CXXFLAGS = ${ALL_CXXFLAGS}
 endif
 #}}}
 #Wrappers {{{
@@ -135,7 +135,7 @@ AM_CXXFLAGS += -fPIC -D_WRAPPERS_
 deps += ./libISSMMatlab.la ../../c/libISSMCore.la ../../c/libISSMModules.la
 
 if !MSYS2
-deps += ./libISSMApi.la
+deps += ./libISSMApi_Matlab.la
 endif
 
 if ADOLC
@@ -156,21 +156,21 @@ libISSMMatlab_la_LIBADD = ./../../c/libISSMCore.la ./../../c/libISSMModules.la $
 
 if VERSION
 libISSMMatlab_la_LDFLAGS =
-libISSMApi_la_LDFLAGS =
+libISSMApi_Matlab_la_LDFLAGS =
 else
 libISSMMatlab_la_LDFLAGS = -avoid-version
-libISSMApi_la_LDFLAGS = -avoid-version
+libISSMApi_Matlab_la_LDFLAGS = -avoid-version
 endif
 
 if STANDALONE_LIBRARIES
 if !MSYS2
 libISSMMatlab_la_LDFLAGS += -static
-libISSMApi_la_LDFLAGS += -static
+libISSMApi_Matlab_la_LDFLAGS += -static
 endif
 deps += $(DAKOTALIB) $(PETSCLIB) $(MUMPSLIB) $(SCALAPACKLIB) $(BLASLAPACKLIB) $(PARMETISLIB) $(METISLIB) $(HDF5LIB) $(TAOLIB) $(M1QN3LIB) $(SEMICLIB) $(PLAPACKLIB) $(SUPERLULIB) $(SPOOLESLIB) $(TRIANGLELIB) $(BLACSLIB) $(HYPRELIB) $(SPAILIB) $(PROMETHEUSLIB) $(PASTIXLIB) $(MLLIB) $(SCOTCHLIB) $(MKLLIB) $(MPILIB) $(NEOPZLIB) $(MATHLIB) $(GRAPHICSLIB) $(MULTITHREADINGLIB) $(GSLLIB) $(ADOLCLIB) $(AMPILIB) $(METEOIOLIB) $(SNOWPACKLIB) $(OSLIBS) ${LIBADD_FOR_MEX}
 endif
 
-libISSMApi_la_LIBADD = $(PETSCLIB) $(MUMPSLIB) $(SCALAPACKLIB) $(BLASLAPACKLIB) $(PARMETISLIB) $(METISLIB) $(HDF5LIB) $(MPILIB) $(NEOPZLIB) $(GSLLIB) $(MATHLIB) $(MEXLIB)
+libISSMApi_Matlab_la_LIBADD = $(PETSCLIB) $(MUMPSLIB) $(SCALAPACKLIB) $(BLASLAPACKLIB) $(PARMETISLIB) $(METISLIB) $(HDF5LIB) $(MPILIB) $(NEOPZLIB) $(GSLLIB) $(MATHLIB) $(MEXLIB)
 
 BamgConvertMesh_matlab_la_SOURCES = ../BamgConvertMesh/BamgConvertMesh.cpp
 BamgConvertMesh_matlab_la_CXXFLAGS = ${AM_CXXFLAGS}

--- a/src/wrappers/python/Makefile.am
+++ b/src/wrappers/python/Makefile.am
@@ -25,13 +25,13 @@ libISSMPython_la_SOURCES = $(io_sources)
 libISSMPython_la_CXXFLAGS= ${ALL_CXXFLAGS}
 #}}}
 #api io{{{
-lib_LTLIBRARIES += libISSMApi.la
+lib_LTLIBRARIES += libISSMApi_Python.la
 
 if !MSYS2
 api_sources= ./io/ApiPrintf.cpp
 
-libISSMApi_la_SOURCES = $(api_sources)
-libISSMApi_la_CXXFLAGS = ${ALL_CXXFLAGS}
+libISSMApi_Python_la_SOURCES = $(api_sources)
+libISSMApi_Python_la_CXXFLAGS = ${ALL_CXXFLAGS}
 endif
 #}}}
 #Wrappers {{{
@@ -120,7 +120,7 @@ AM_CXXFLAGS += -fPIC -D_WRAPPERS_
 deps += ./libISSMPython.la ../../c/libISSMModules.la ../../c/libISSMCore.la
 
 if !MSYS2
-deps += ./libISSMApi.la
+deps += ./libISSMApi_Python.la
 endif
 
 if ADOLC
@@ -142,12 +142,12 @@ libISSMPython_la_LIBADD = ./../../c/libISSMCore.la ./../../c/libISSMModules.la $
 if STANDALONE_LIBRARIES
 if !MSYS2
 libISSMPython_la_LDFLAGS = -static
-libISSMApi_la_LDFLAGS = -static
+libISSMApi_Python_la_LDFLAGS = -static
 endif
 deps += $(DAKOTALIB) $(PETSCLIB) $(MUMPSLIB) $(SCALAPACKLIB) $(BLASLAPACKLIB) $(PARMETISLIB) $(METISLIB) $(HDF5LIB) $(TAOLIB) $(M1QN3LIB) $(SEMICLIB) $(PLAPACKLIB) $(SUPERLULIB) $(SPOOLESLIB) $(TRIANGLELIB) $(BLACSLIB) $(HYPRELIB) $(SPAILIB) $(PROMETHEUSLIB) $(PASTIXLIB) $(MLLIB) $(SCOTCHLIB) $(MKLLIB) $(MPILIB) $(NEOPZLIB) $(MATHLIB) $(GRAPHICSLIB) $(MULTITHREADINGLIB) $(GSLLIB) $(ADOLCLIB) $(AMPILIB) $(METEOIOLIB) $(SNOWPACKLIB) $(OSLIBS) $(PYTHONLIB)
 endif
 
-libISSMApi_la_LIBADD = $(PETSCLIB) $(MUMPSLIB) $(SCALAPACKLIB) $(BLASLAPACKLIB) $(PARMETISLIB) $(METISLIB) $(HDF5LIB) $(MPILIB) $(NEOPZLIB) $(GSLLIB) $(MATHLIB)
+libISSMApi_Python_la_LIBADD = $(PETSCLIB) $(MUMPSLIB) $(SCALAPACKLIB) $(BLASLAPACKLIB) $(PARMETISLIB) $(METISLIB) $(HDF5LIB) $(MPILIB) $(NEOPZLIB) $(GSLLIB) $(MATHLIB)
 
 BamgConvertMesh_python_la_SOURCES = ../BamgConvertMesh/BamgConvertMesh.cpp
 BamgConvertMesh_python_la_CXXFLAGS = ${AM_CXXFLAGS}


### PR DESCRIPTION
* Resolve issue: Error in compiling both Matlab and Python.
* See also https://github.com/ISSMteam/ISSM/issues/27.
* Rename "libISSMApi" in Makefile.am for the wrappers, such as java, matlab, and python.
   * Matlab: libISSMApi > libISSMApi_Matlab.
   * Python: libISSMApi > libISSMApi_Python.
   * Java: libISSMApi > libISSMApi_Java.

     modified:        src/wrappers/javascript/Makefile.am
     modified:        src/wrappers/matlab/Makefile.am
     modified:        src/wrappers/python/Makefile.am