### PR TITLE
CHG: Resolve using "issmscpin.m" for downloading files in the remote server.

### DIFF
--- a/src/m/os/issmscpin.m
+++ b/src/m/os/issmscpin.m
@@ -27,15 +27,28 @@ else
 	else
 		fileliststr='';
 		for i=1:numel(packages)-1,
-			fileliststr=[fileliststr filelist{i} ' '];
+			fileliststr=[fileliststr path '/' packages{i} ' '];
 		end
-		fileliststr=[fileliststr filelist{end}];
+		fileliststr=[fileliststr path '/' packages{end}];
 	end
 
+	%get ssh version
+	v = sshversion;
+
+	%NOTE: scp option "-O" and "-T" is added in version "OpenSSH 8.7" (2021 Aug.).
+	%Before "OpenSSH 8.7", scp with "-O" and "-T" option does not works.
 	if port,
-		eval(['!scp -OT -P ' num2str(port) ' ' login '@localhost:"' fileliststr '" .']);
+		if v.date > datetime(2021,8,1)
+			eval(['!scp -OT -P ' num2str(port) ' ' login '@localhost:"' fileliststr '" .']);
+		else
+			eval(['!scp -P ' num2str(port) ' ' login '@localhost:"' fileliststr '" .']);
+		end
 	else
-		eval(['!scp -OT ' login '@' host ':"' fileliststr '" .']);
+		if v.date > datetime(2021,8,1)
+			eval(['!scp -OT ' login '@' host ':"' fileliststr '" .']);
+		else
+			eval(['!scp ' login '@' host ':"' fileliststr '" .']);
+		end
 	end
 
 	%check scp worked

--- a/src/m/os/sshversion.m
+++ b/src/m/os/sshversion.m
@@ -1,0 +1,23 @@
+function v = sshversion(inputs)
+%SSHVERSION get ssh version, using "ssh" on unix.
+%
+% Usage
+%  v = sshversion;
+%}
+
+%Get ssh version
+[status, stdout] = system('ssh -V');
+
+if status ~= 0
+	error(sprintf('ERROR: check error message: %s', stdout));
+end
+
+% search date.
+pattern = '(?<month>\d{1,2}) (?<day>[A-Za-z]{3}) (?<year>\d{4})';
+match = regexp(stdout, pattern, 'match');
+
+% return ssh version information.
+v = struct('version',stdout,...
+	'date',datetime(match,'InputFormat','dd MMM yyyy'));
+
+end

--- a/src/wrappers/javascript/Makefile.am
+++ b/src/wrappers/javascript/Makefile.am
@@ -35,12 +35,12 @@ libISSMJavascript_la_SOURCES = $(io_sources)
 libISSMJavascript_la_CXXFLAGS= $(ALLCXXFLAGS)
 #}}}
 # API I/O{{{
-lib_LTLIBRARIES += libISSMApi.la
+lib_LTLIBRARIES += libISSMApi_Java.la
 
 api_sources= ./io/ApiPrintf.cpp
 
-libISSMApi_la_SOURCES = $(api_sources)
-libISSMApi_la_CXXFLAGS= $(ALLCXXFLAGS)
+libISSMApi_Java_la_SOURCES = $(api_sources)
+libISSMApi_Java_la_CXXFLAGS= $(ALLCXXFLAGS)
 #}}}
 # Wrappers {{{
 bin_PROGRAMS = IssmModule
@@ -52,7 +52,7 @@ bin_PROGRAMS = IssmModule
 AM_CXXFLAGS = -DTRILIBRARY -DANSI_DECLARATORS -DNO_TIMER -D_WRAPPERS_
 AM_CXXFLAGS += -D_HAVE_JAVASCRIPT_MODULES_ -fPIC
 
-deps = ./libISSMJavascript.la ../../c/libISSMModules.la ../../c/libISSMCore.la ./libISSMApi.la
+deps = ./libISSMJavascript.la ../../c/libISSMModules.la ../../c/libISSMCore.la ./libISSMApi_Java.la
 
 # Optimization flags
 AM_CXXFLAGS += $(CXXFLAGS)
@@ -62,21 +62,21 @@ libISSMJavascript_la_LIBADD = ./../../c/libISSMCore.la ./../../c/libISSMModules.
 
 if VERSION
 libISSMJavascript_la_LDFLAGS =
-libISSMApi_la_LDFLAGS =
+libISSMApi_Java_la_LDFLAGS =
 else
 libISSMJavascript_la_LDFLAGS = -avoid-version
-libISSMApi_la_LDFLAGS = -avoid-version
+libISSMApi_Java_la_LDFLAGS = -avoid-version
 endif
 
 if STANDALONE_LIBRARIES
 if !MSYS2
 libISSMJavascript_la_LDFLAGS += -static
-libISSMApi_la_LDFLAGS += -static
+libISSMApi_Java_la_LDFLAGS += -static
 endif
 deps += $(DAKOTALIB) $(PETSCLIB) $(MUMPSLIB) $(SCALAPACKLIB) $(BLASLAPACKLIB) $(PARMETISLIB) $(METISLIB) $(HDF5LIB) $(TAOLIB) $(M1QN3LIB) $(SEMICLIB) $(PLAPACKLIB) $(SUPERLULIB) $(SPOOLESLIB) $(TRIANGLELIB) $(BLACSLIB) $(HYPRELIB) $(SPAILIB) $(PROMETHEUSLIB) $(PASTIXLIB) $(MLLIB) $(SCOTCHLIB) $(MKLLIB) $(MPILIB) $(NEOPZLIB) $(MATHLIB) $(GRAPHICSLIB) $(MULTITHREADINGLIB) $(GSLLIB) $(ADOLCLIB) $(AMPILIB) $(METEOIOLIB) $(SNOWPACKLIB) $(PROJLIB) $(OSLIBS)
 endif
 
-libISSMApi_la_LIBADD = $(PETSCLIB) $(MUMPSLIB) $(SCALAPACKLIB) $(BLASLAPACKLIB) $(PARMETISLIB) $(METISLIB) $(HDF5LIB) $(MPILIB) $(NEOPZLIB) $(GSLLIB) $(PROJLIB) $(MATHLIB)
+libISSMApi_Java_la_LIBADD = $(PETSCLIB) $(MUMPSLIB) $(SCALAPACKLIB) $(BLASLAPACKLIB) $(PARMETISLIB) $(METISLIB) $(HDF5LIB) $(MPILIB) $(NEOPZLIB) $(GSLLIB) $(PROJLIB) $(MATHLIB)
 
 IssmModule_SOURCES = \
 	../BamgMesher/BamgMesher.cpp \

--- a/src/wrappers/matlab/Makefile.am
+++ b/src/wrappers/matlab/Makefile.am
@@ -27,13 +27,13 @@ libISSMMatlab_la_SOURCES = $(io_sources)
 libISSMMatlab_la_CXXFLAGS = ${ALL_CXXFLAGS}
 #}}}
 #api io{{{
-lib_LTLIBRARIES += libISSMApi.la
+lib_LTLIBRARIES += libISSMApi_Matlab.la
 
 if !MSYS2
 api_sources= ./io/ApiPrintf.cpp
 
-libISSMApi_la_SOURCES = $(api_sources)
-libISSMApi_la_CXXFLAGS = ${ALL_CXXFLAGS}
+libISSMApi_Matlab_la_SOURCES = $(api_sources)
+libISSMApi_Matlab_la_CXXFLAGS = ${ALL_CXXFLAGS}
 endif
 #}}}
 #Wrappers {{{
@@ -135,7 +135,7 @@ AM_CXXFLAGS += -fPIC -D_WRAPPERS_
 deps += ./libISSMMatlab.la ../../c/libISSMCore.la ../../c/libISSMModules.la
 
 if !MSYS2
-deps += ./libISSMApi.la
+deps += ./libISSMApi_Matlab.la
 endif
 
 if ADOLC
@@ -156,21 +156,21 @@ libISSMMatlab_la_LIBADD = ./../../c/libISSMCore.la ./../../c/libISSMModules.la $
 
 if VERSION
 libISSMMatlab_la_LDFLAGS =
-libISSMApi_la_LDFLAGS =
+libISSMApi_Matlab_la_LDFLAGS =
 else
 libISSMMatlab_la_LDFLAGS = -avoid-version
-libISSMApi_la_LDFLAGS = -avoid-version
+libISSMApi_Matlab_la_LDFLAGS = -avoid-version
 endif
 
 if STANDALONE_LIBRARIES
 if !MSYS2
 libISSMMatlab_la_LDFLAGS += -static
-libISSMApi_la_LDFLAGS += -static
+libISSMApi_Matlab_la_LDFLAGS += -static
 endif
 deps += $(DAKOTALIB) $(PETSCLIB) $(MUMPSLIB) $(SCALAPACKLIB) $(BLASLAPACKLIB) $(PARMETISLIB) $(METISLIB) $(HDF5LIB) $(TAOLIB) $(M1QN3LIB) $(SEMICLIB) $(PLAPACKLIB) $(SUPERLULIB) $(SPOOLESLIB) $(TRIANGLELIB) $(BLACSLIB) $(HYPRELIB) $(SPAILIB) $(PROMETHEUSLIB) $(PASTIXLIB) $(MLLIB) $(SCOTCHLIB) $(MKLLIB) $(MPILIB) $(NEOPZLIB) $(MATHLIB) $(GRAPHICSLIB) $(MULTITHREADINGLIB) $(GSLLIB) $(ADOLCLIB) $(AMPILIB) $(METEOIOLIB) $(SNOWPACKLIB) $(OSLIBS) ${LIBADD_FOR_MEX}
 endif
 
-libISSMApi_la_LIBADD = $(PETSCLIB) $(MUMPSLIB) $(SCALAPACKLIB) $(BLASLAPACKLIB) $(PARMETISLIB) $(METISLIB) $(HDF5LIB) $(MPILIB) $(NEOPZLIB) $(GSLLIB) $(MATHLIB) $(MEXLIB)
+libISSMApi_Matlab_la_LIBADD = $(PETSCLIB) $(MUMPSLIB) $(SCALAPACKLIB) $(BLASLAPACKLIB) $(PARMETISLIB) $(METISLIB) $(HDF5LIB) $(MPILIB) $(NEOPZLIB) $(GSLLIB) $(MATHLIB) $(MEXLIB)
 
 BamgConvertMesh_matlab_la_SOURCES = ../BamgConvertMesh/BamgConvertMesh.cpp
 BamgConvertMesh_matlab_la_CXXFLAGS = ${AM_CXXFLAGS}

--- a/src/wrappers/python/Makefile.am
+++ b/src/wrappers/python/Makefile.am
@@ -25,13 +25,13 @@ libISSMPython_la_SOURCES = $(io_sources)
 libISSMPython_la_CXXFLAGS= ${ALL_CXXFLAGS}
 #}}}
 #api io{{{
-lib_LTLIBRARIES += libISSMApi.la
+lib_LTLIBRARIES += libISSMApi_Python.la
 
 if !MSYS2
 api_sources= ./io/ApiPrintf.cpp
 
-libISSMApi_la_SOURCES = $(api_sources)
-libISSMApi_la_CXXFLAGS = ${ALL_CXXFLAGS}
+libISSMApi_Python_la_SOURCES = $(api_sources)
+libISSMApi_Python_la_CXXFLAGS = ${ALL_CXXFLAGS}
 endif
 #}}}
 #Wrappers {{{
@@ -120,7 +120,7 @@ AM_CXXFLAGS += -fPIC -D_WRAPPERS_
 deps += ./libISSMPython.la ../../c/libISSMModules.la ../../c/libISSMCore.la
 
 if !MSYS2
-deps += ./libISSMApi.la
+deps += ./libISSMApi_Python.la
 endif
 
 if ADOLC
@@ -142,12 +142,12 @@ libISSMPython_la_LIBADD = ./../../c/libISSMCore.la ./../../c/libISSMModules.la $
 if STANDALONE_LIBRARIES
 if !MSYS2
 libISSMPython_la_LDFLAGS = -static
-libISSMApi_la_LDFLAGS = -static
+libISSMApi_Python_la_LDFLAGS = -static
 endif
 deps += $(DAKOTALIB) $(PETSCLIB) $(MUMPSLIB) $(SCALAPACKLIB) $(BLASLAPACKLIB) $(PARMETISLIB) $(METISLIB) $(HDF5LIB) $(TAOLIB) $(M1QN3LIB) $(SEMICLIB) $(PLAPACKLIB) $(SUPERLULIB) $(SPOOLESLIB) $(TRIANGLELIB) $(BLACSLIB) $(HYPRELIB) $(SPAILIB) $(PROMETHEUSLIB) $(PASTIXLIB) $(MLLIB) $(SCOTCHLIB) $(MKLLIB) $(MPILIB) $(NEOPZLIB) $(MATHLIB) $(GRAPHICSLIB) $(MULTITHREADINGLIB) $(GSLLIB) $(ADOLCLIB) $(AMPILIB) $(METEOIOLIB) $(SNOWPACKLIB) $(OSLIBS) $(PYTHONLIB)
 endif
 
-libISSMApi_la_LIBADD = $(PETSCLIB) $(MUMPSLIB) $(SCALAPACKLIB) $(BLASLAPACKLIB) $(PARMETISLIB) $(METISLIB) $(HDF5LIB) $(MPILIB) $(NEOPZLIB) $(GSLLIB) $(MATHLIB)
+libISSMApi_Python_la_LIBADD = $(PETSCLIB) $(MUMPSLIB) $(SCALAPACKLIB) $(BLASLAPACKLIB) $(PARMETISLIB) $(METISLIB) $(HDF5LIB) $(MPILIB) $(NEOPZLIB) $(GSLLIB) $(MATHLIB)
 
 BamgConvertMesh_python_la_SOURCES = ../BamgConvertMesh/BamgConvertMesh.cpp
 BamgConvertMesh_python_la_CXXFLAGS = ${AM_CXXFLAGS}


### PR DESCRIPTION
# CHG: Fix downloading files in remote server using "issmscpin.m".
        
    modified:   src/m/os/issmscpin.m
    new file:   src/m/os/sshversion.m

* Depending on "ssh" verion. "scp -OT" option does not work with old ssh version (e.g., OpenSSH_7.4p1, OpenSSL 1.0.2k-fips  26 Jan 2017) does not work.
* The "scp -OT" option is only available starting from OpeenSSH 8.7 (released in 2024 Aug.).
* Add "sshversion.m" to determine SSH version in "issmscipin.m".

* Fix 'filterliststr' in "issmscipin.m". Incorrect usage by ading the approprite path for remote server files.