### PR TITLE
CHG: Fix default value for decreasing downward longwave radiation with a value of 29 W m-2 km-1.

### DIFF
--- a/src/c/classes/Elements/Element.cpp
+++ b/src/c/classes/Elements/Element.cpp
@@ -4851,7 +4851,8 @@ void       Element::SmbSemicTransient(){/*{{{*/
 		}
 
 		/* downward longwave radiation correction (Marty et al. 2002) */
-		st[iv]=(s[iv]-s0gcm[iv])/1000.;
+        /* Unit of "md.smb.rdl" is defined in W m-2 km-1 */
+		st[iv]=(s[iv]-s0gcm[iv])/1000.; /* unit in km */
 		dailydlradiation[iv]=dailydlradiation[iv]+rdl*st[iv];
 	}
 	if(isverbose && this->Sid()==0){

--- a/src/m/classes/SMBsemic.m
+++ b/src/m/classes/SMBsemic.m
@@ -159,9 +159,9 @@ classdef SMBsemic
 			self.rcrit = 0.85; % from Krapp et al. (2017)
 		
 			self.desfac		      = -log(2.0)/1000;
-			self.desfacElevation = 2000;
+			self.desfacElevation  = 2000;
 			self.rlaps		      = 7.4;
-			self.rdl			      = 0.29;
+			self.rdl			  = 29; % from  Marty et al. (2002)
 
 			self.ismethod        = 0;
 			self.requested_outputs={'default'};
@@ -235,7 +235,7 @@ classdef SMBsemic
 			fielddisplay(self,'dailytemperature','daily surface air temperature [K]');
 			fielddisplay(self,'rlaps','present day lapse rate (default is 7.4 [degree/km]; Erokhina et al. 2017)');
 			fielddisplay(self,'desfac','desertification elevation factor (default is -log(2.0)/1000 [1/km]; Vizcaino et al. 2010)');
-			fielddisplay(self,'rdl','longwave downward radiation decrease (default is 0.29 [W/m^2/km]; Marty et al. 2002)');
+			fielddisplay(self,'rdl','longwave downward radiation decrease (default is 29 [W/m^2/km]; Marty et al. 2002)');
 			fielddisplay(self,'s0gcm','GCM reference elevation; (default is 0) [m]');
 
 			fielddisplay(self,'ismethod','method for calculating SMB with SEMIC. Default version of SEMIC is really slow. 0: steady, 1: transient (default: 0)');

--- a/src/m/classes/SMBsemic.py
+++ b/src/m/classes/SMBsemic.py
@@ -92,7 +92,7 @@ class SMBsemic(object):
         s += '{}\n'.format(fielddisplay(self, 'dailyairhumidity', 'daily air specific humidity [kg/kg]'))
         s += '{}\n'.format(fielddisplay(self, 'rlaps', 'present day lapse rate (default is 7.4 [degree/km]; Erokhina et al. 2017)'))
         s += '{}\n'.format(fielddisplay(self, 'desfac', 'desertification elevation factor (default is -log(2.0)/1000 [1/km]; Vizcaino et al. 2010)'))
-        s += '{}\n'.format(fielddisplay(self, 'rdl', 'longwave downward radiation decrease (default is 0.29 [W/m^2/km]; Marty et al. 2002)'))
+        s += '{}\n'.format(fielddisplay(self, 'rdl', 'longwave downward radiation decrease (default is 29 [W/m^2/km]; Marty et al. 2002)'))
         s += '{}\n'.format(fielddisplay(self, 's0gcm', 'GCM reference elevation; (default is 0) [m]'))
         s += '{}\n'.format(fielddisplay(self, 'ismethod','method for calculating SMB with SEMIC. Default version of SEMIC is really slow. 0: steady, 1: transient (default: 0)'))
         if self.ismethod: # transient mode
@@ -228,7 +228,7 @@ class SMBsemic(object):
         self.desfac = -log(2.0) / 1000
         self.desfacElevation = 2000
         self.rlaps = 7.4
-        self.rdl = 0.29
+        self.rdl   = 29 # from Marty et al. (2002)
 
         self.ismethod = 0
         self.requested_outputs = ['default']


### PR DESCRIPTION
Update annotation for SEMIC in "Element.cpp"
	modified:   src/c/classes/Elements/Element.cpp

Fix default value of "md.smb.rdl" with 29 W m-2 km-1.
	modified:   src/m/classes/SMBsemic.m
	modified:   src/m/classes/SMBsemic.py