### PR TITLE
Add Amundsen path to ISMIP6 interp functions

### DIFF
--- a/src/m/parameterization/interpISMIP6AntarcticaOcn.m
+++ b/src/m/parameterization/interpISMIP6AntarcticaOcn.m
@@ -29,7 +29,9 @@ function basalforcings = interpISMIP6AntarcticaOcn(md,model_name)
 % Find appropriate directory
 switch oshostname(),
 	case {'totten'}
-		path='/totten_1/ModelData/ISMIP6/Projections/AIS/Ocean_Forcing/';
+	        path='/totten_1/ModelData/ISMIP6/Projections/AIS/Ocean_Forcing/';
+        case {'amundsen.thayer.dartmouth.edu'}
+                path='/local/ModelData/ISMIP6Data/Forcings2100/Atmosphere/';
 	otherwise
 		error('machine not supported yet, please provide your own path');
 end

--- a/src/m/parameterization/interpISMIP6AntarcticaSMB.m
+++ b/src/m/parameterization/interpISMIP6AntarcticaSMB.m
@@ -22,12 +22,14 @@ function smb = interpISMIP6AntarcticaSMB(md,model_name)
 %            time series from 1995-2100
 %
 %   Examples:
-%      md.smb = interpISMIP6AntarcticaSMB(md,'miroc-esm-chem_rcp8.5');
+%      Omd.smb = interpISMIP6AntarcticaSMB(md,'miroc-esm-chem_rcp8.5');
 
 % Find appropriate directory
 switch oshostname(),
-	case {'totten'}
-		path='/totten_1/ModelData/ISMIP6/Projections/AIS/Atmosphere_Forcing/';
+        case {'totten'}
+                 path='/totten_1/ModelData/ISMIP6/Projections/AIS/Atmosphere_Forcing/';
+        case {'amundsen.thayer.dartmouth.edu'}
+                 path='/local/ModelData/ISMIP6Data/Forcings2100/Atmosphere/';
 	otherwise
 		error('machine not supported yet, please provide your own path');
 end


### PR DESCRIPTION
If there is a way to make the string for amundsen just 'amundsen' instead of 'amundsen.thayer.dartmouth.edu' that would probably be nicer, but I'm not sure how to do that.