### PR TITLE
CHG: loadmodel_netcdf.py - skip loading mmemasstransport in Python. 

### DIFF
--- a/src/m/contrib/inwoo/loadmodel_netcdf.py
+++ b/src/m/contrib/inwoo/loadmodel_netcdf.py
@@ -133,6 +133,10 @@ def loadmodel_netcdf(filename, verbose:bool=0):
                 md.outputdefinition.definitions = []
             else:
                 md.outputdefinition.definitions = definitions
+        elif groupName in 'mmemasstransport':
+            # NOTE: mmemasstransport is not implemented in python.
+            warnings.warn('WARNING: "mmemasstransport" is not implemented in Python.')
+            continue
         elif (not mclass in ['verbose',
                                 'hpc_simba','fourierlove',
                                 ]) & isinstance(gclass,str): # skip specific class..


### PR DESCRIPTION
* "memasstransport" is not yet implemented in python. Therefore, we skip loading "mmemasstransport" in Python version.