### PR TITLE
BUG: only write part of large outlogs and errlogs

### DIFF
--- a/src/m/solve/loadresultsfromdisk.m
+++ b/src/m/solve/loadresultsfromdisk.m
@@ -55,7 +55,7 @@ if ~md.qmu.isdakota,
 	end
 
 	if exist([md.miscellaneous.name '.outlog'],'file'),
-		md.results.(structure(1).SolutionType)(1).outlog=char(textread([md.miscellaneous.name '.outlog'],'%s',1000,'delimiter','\n'));
+		md.results.(structure(1).SolutionType)(1).outlog=char(textread([md.miscellaneous.name '.outlog'],'%c',4000,'delimiter','\n'));
 	else
 		md.results.(structure(1).SolutionType)(1).outlog='';
 	end


### PR DESCRIPTION
Limited how much of an outlog and errorlog will be saved in the model in case of very large outlogs or errlogs.