### PR TITLE
added -l option for sourcing bashrc on andes when running a batch script

### DIFF
--- a/src/m/classes/clusters/andes.m
+++ b/src/m/classes/clusters/andes.m
@@ -97,7 +97,7 @@ classdef andes
 
 			%write queuing script
 			fid=fopen([modelname '.queue'],'w');
-			fprintf(fid,'#!/bin/bash\n');
+			fprintf(fid,'#!/bin/bash -l\n');
 			fprintf(fid,'#SBATCH --job-name=%s\n',modelname);
 			fprintf(fid,'#SBATCH --account=ice\n'); %Make sure we use the ICE account for this run
 			fprintf(fid,'#SBATCH -o %s.outlog \n',modelname);
@@ -111,9 +111,6 @@ classdef andes
 				fprintf(fid,'#SBATCH --mail-user=%s@%s\n',cluster.login, cluster.email_domain);
 			end
 			fprintf(fid,'\n');
-			fprintf(fid,'export ISSM_DIR="%s/../"\n',cluster.codepath);
-			fprintf(fid,'source $ISSM_DIR/etc/environment.sh\n');
-			fprintf(fid,'cd %s/%s\n\n',cluster.executionpath,dirname);
 			fprintf(fid,'mpirun -n %i %s/issm.exe %s %s %s\n',cluster.nprocs(), cluster.codepath,solution,[cluster.executionpath '/' dirname],modelname);
 			if ~io_gather, %concatenate the output files:
 				fprintf(fid,'cat %s.outbin.* > %s.outbin',modelname,modelname);


### PR DESCRIPTION
"-l" sources the users bashrc on andes which probably better than having to add prerun commands to the batch file.