### PR TITLE
added Z values to matlab plots datatips

### DIFF
--- a/src/m/plot/plot_unit.m
+++ b/src/m/plot/plot_unit.m
@@ -62,9 +62,13 @@ switch datatype,
 			patch( 'Faces',[B C D],'Vertices', [x y z],'FaceVertexCData',data(:),'FaceColor','interp','EdgeColor',edgecolor);
 			patch( 'Faces',[C A D],'Vertices', [x y z],'FaceVertexCData',data(:),'FaceColor','interp','EdgeColor',edgecolor);
 		else
-			A=elements(:,1); B=elements(:,2); C=elements(:,3); 
-			patch( 'Faces', [A B C], 'Vertices', [x y z],'FaceVertexCData', data(:),'FaceColor','interp','EdgeColor',edgecolor);
-		end
+                        A=elements(:,1); B=elements(:,2); C=elements(:,3); 
+                        p = patch( 'Faces', [A B C], 'Vertices', [x y z],'FaceVertexCData', data(:), 'FaceColor','interp','EdgeColor',edgecolor);
+                        tip = datatip(p,x(1),y(1),'Visible','off');
+                        p.UserData = data(:);
+                        row = dataTipTextRow('Z', 'UserData');
+                        p.DataTipTemplate.DataTipRows(3) = row;
+                end
 
 	%quiver plot
 	case 3,


### PR DESCRIPTION
The purpose of this is to be able to easily identify where certain vertex indices are spatially by doing:

`plotmodel(md, 'data', 1:md.numberofvertices)`

This helps if a model variable needs to be observed at a single point.
It is much faster than the alternative:

`plotmodel(md, 'data', 'vertexnumbering')`

It also has the added benefit that any plotted field value can be seen with the cursor when moving over the plot.