### PR TITLE
add vertex number to plots datatips

### DIFF
--- a/src/m/plot/plot_unit.m
+++ b/src/m/plot/plot_unit.m
@@ -62,8 +62,12 @@ switch datatype,
 			patch( 'Faces',[B C D],'Vertices', [x y z],'FaceVertexCData',data(:),'FaceColor','interp','EdgeColor',edgecolor);
 			patch( 'Faces',[C A D],'Vertices', [x y z],'FaceVertexCData',data(:),'FaceColor','interp','EdgeColor',edgecolor);
 		else
-			A=elements(:,1); B=elements(:,2); C=elements(:,3); 
-			patch( 'Faces', [A B C], 'Vertices', [x y z],'FaceVertexCData', data(:),'FaceColor','interp','EdgeColor',edgecolor);
+                        A=elements(:,1); B=elements(:,2); C=elements(:,3); 
+                        p = patch( 'Faces', [A B C], 'Vertices', [x y z],'FaceVertexCData', data(:), 'FaceColor','interp','EdgeColor',edgecolor);
+                        tip = datatip(p,x(1),y(1),'Visible','off');
+                        p.UserData = 1:length(x);
+                        row = dataTipTextRow('Vertex', 'UserData');
+                        p.DataTipTemplate.DataTipRows(3) = row;
 		end
 
 	%quiver plot


### PR DESCRIPTION
The purpose of this is to be able to easily identify where certain vertex indices are spatially when scrolling over the output of plotmodel. This helps find the correct vertex if a model variable needs to be observed at a single point.