### PR TITLE
Add release CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,24 @@
+on:
+  push:
+    tags:
+      - '*'
+    branches:
+      - access-release
+
+jobs:
+  create-release:
+    runs-on: ubuntu-latest
+
+    permissions:
+        contents: write
+
+    steps:
+      - name: Checkout copy of repository
+        uses: actions/checkout@v4
+
+      - name: Create GitHub release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: ${{ github.ref_name }}
+          generate_release_notes: true


### PR DESCRIPTION
Add CI to generate Github release when a tag is pushed to `access-release`