### PR TITLE
Update CI external package command

### DIFF
--- a/.github/workflows/common-workflow.yml
+++ b/.github/workflows/common-workflow.yml
@@ -70,7 +70,7 @@ jobs:
       - name: Prepare external packages
         if: ${{ steps.cache-externalpackages.outputs.cache-hit != 'true' }}
         run: |
-          ${{ inputs.ext_install_command }}
+          ${{ inputs.ext_pkg_build_command }}
 
       - name: Get MATLAB
         if: ${{ inputs.interface == 'matlab' }}


### PR DESCRIPTION
CI passes on ISSMteam/ISSM because of cached external packages. It fails on forks without a cache because external packages are never installed.

Rename `ext_install_command` to `ext_pkg_build_command` in `common-workflow.yml`.