### PR TITLE
fix: check verbose flag before printing to terminal

### DIFF
--- a/src/c/classes/FemModel.cpp
+++ b/src/c/classes/FemModel.cpp
@@ -979,7 +979,7 @@ void FemModel::Solve(void){/*{{{*/
 	int solution_type;
 	void (*solutioncore)(FemModel*)=NULL; //core solution function pointer
 
-	_printf0_("call computational core:\n");
+	if(VerboseSolution()) _printf0_("call computational core:\n");
 
 	/*Retrieve solution_type from parameters: */
 	parameters->FindParam(&solution_type,SolutionTypeEnum);


### PR DESCRIPTION
Is it OK to make this terminal output optional? Sometimes I prefer ISSM to shut up :)

I felt `VerboseSolution` is the right flag to use?