### PR TITLE
AD cost function minimum tracking

### DIFF
--- a/src/c/cores/controladm1qn3_core.cpp
+++ b/src/c/cores/controladm1qn3_core.cpp
@@ -38,7 +38,8 @@ typedef struct{
 	int*         i;
 	int*         imin;
 	double*      Jmin;
-	Issmdouble*  Xmin;
+	IssmDouble*  Xmin;
+	IssmDouble*  Gmin;
 } m1qn3_struct;
 /*}}}*/
 
@@ -162,7 +163,8 @@ void simul_ad(long* indic,long* n,double* X,double* pf,double* G,long izs[1],flo
 	int*          Jlisti    = input_struct->i;
 	int*          Jlistimin = input_struct->imin;
 	double*       Jmin      = input_struct->Jmin;
-	IssmDouble*   Xmin      = input_struct->Xmin;	
+	IssmDouble*   Xmin      = input_struct->Xmin;
+	IssmDouble*   Gmin      = input_struct->Gmin;	
 	int           intn   = (int)*n;	
 	/*Recover some parameters*/
 	double *scaling_factors = NULL;
@@ -264,9 +266,10 @@ void simul_ad(long* indic,long* n,double* X,double* pf,double* G,long izs[1],flo
 
 		/* save control field and iteration if the minimum so far */
 		if (J < *Jmin){
-		  *Jmin = J;
+		  *Jmin = reCast<double>(J);
 		  *Jlistimin = *Jlisti;
-		  *Xmin = aX;
+		  Xmin = reCast<IssmDouble*>(aX);
+		  Gmin = reCast<IssmDouble*>(G);
 		}		
 		
 		#if defined(_HAVE_CODIPACK_)
@@ -495,9 +498,10 @@ void controladm1qn3_core(FemModel* femmodel){/*{{{*/
 	mystruct.Jlist    = xNewZeroInit<IssmPDouble>(mystruct.M*mystruct.N);	
 	mystruct.i        = xNewZeroInit<int>(1);
 	mystruct.imin     = xNewZeroInit<int>(1);
-	mystruct.Jmin     = xNewZeroInit<int>(1);
+	mystruct.Jmin     = xNewZeroInit<double>(1);
 	*(mystruct.Jmin)  = std::numeric_limits<double>::infinity();
-	mystruct.Xmin     = xNewZeroInit<IssmDouble>(nint);
+	mystruct.Xmin     = xNewZeroInit<IssmDouble>(n);
+	mystruct.Gmin     = xNewZeroInit<IssmDouble>(n);
 	/*Initialize Gradient and cost function of M1QN3*/
 	indic = 4; /*gradient required*/
 	simul_ad(&indic,&n,X,&f,G,izs,rzs,(void*)&mystruct);
@@ -526,7 +530,7 @@ void controladm1qn3_core(FemModel* femmodel){/*{{{*/
 		case 7:  _printf0_(": <g,d> > 0  or  <y,s> <0\n"); break;
 		default: _printf0_(": Unknown end condition\n");
 	}
-	_printf0_("   Cost function minimum occured on iteration "<<int(mystruct.imin));
+	_printf0_("   Cost function minimum occured on iteration "<<int(*mystruct.imin));
 	
 	/*Constrain solution vector*/
 	double  *XL = NULL;
@@ -534,33 +538,22 @@ void controladm1qn3_core(FemModel* femmodel){/*{{{*/
 	GetPassiveVectorFromControlInputsx(&XL,NULL,femmodel->elements,femmodel->nodes,femmodel->vertices,femmodel->loads,femmodel->materials,femmodel->parameters,"lowerbound");
 	GetPassiveVectorFromControlInputsx(&XU,NULL,femmodel->elements,femmodel->nodes,femmodel->vertices,femmodel->loads,femmodel->materials,femmodel->parameters,"upperbound");
 
-	/* retrive controls corresponding to minimum cost function value */
-	X = mystruct.Xmin;
-	
+	IssmDouble *Xmin = mystruct.Xmin;
 	offset = 0;
 	for (int c=0;c<num_controls;c++){
 	  for(int i=0;i<M[c]*N[c];i++){
 	    int index = offset+i;
-	    X[index] = X[index]*scaling_factors[c];
-	    if(X[index]>XU[index]) X[index]=XU[index];
-	    if(X[index]<XL[index]) X[index]=XL[index];
+	    Xmin[index] = Xmin[index]*scaling_factors[c];
+	    if(Xmin[index]>XU[index]) Xmin[index]=XU[index];
+	    if(Xmin[index]<XL[index]) Xmin[index]=XL[index];
 	  }
 	  offset += M[c]*N[c];
 	}
 
-	/*Set X as our new control*/
-	IssmDouble* aX=xNew<IssmDouble>(intn);
-	IssmDouble* aG=xNew<IssmDouble>(intn);
-
-	for(int i=0;i<intn;i++) {
-		aX[i] = reCast<IssmDouble>(X[i]);
-		aG[i] = reCast<IssmDouble>(G[i]);
-	}
-
-	ControlInputSetGradientx(femmodel->elements,femmodel->nodes,femmodel->vertices,femmodel->loads,femmodel->materials,femmodel->parameters,aG);
-	SetControlInputsFromVectorx(femmodel,aX);
-	xDelete(aX);
-
+	ControlInputSetGradientx(femmodel->elements,femmodel->nodes,femmodel->vertices,femmodel->loads,femmodel->materials,femmodel->parameters,mystruct.Gmin);
+	SetControlInputsFromVectorx(femmodel, Xmin);
+	xDelete(Xmin);
+	
 	if (solution_type == TransientSolutionEnum){
 		int step = 1;
 		femmodel->parameters->SetParam(step,StepEnum);
@@ -591,7 +584,6 @@ void controladm1qn3_core(FemModel* femmodel){/*{{{*/
 	}
 	femmodel->results->AddObject(new GenericExternalResult<int>(femmodel->results->Size()+1,InversionStopFlagEnum,int(omode)));
 
-	xDelete(aG);
 
 	/*Add last cost function to results*/
 

--- a/src/c/cores/controladm1qn3_core.cpp
+++ b/src/c/cores/controladm1qn3_core.cpp
@@ -396,7 +396,7 @@ void simul_ad(long* indic,long* n,double* X,double* pf,double* G,long izs[1],flo
 	_assert_(!xIsNan(Gnorm));
 	_assert_(!xIsInf(Gnorm));
 
-	/* save control field and iteration if the minimum so far */
+	/* save control field and iteration if this is the minimum so far*/
 	if (J < *Jmin){
 	  *Jmin = reCast<double>(J);
 	  *Jlistimin = *Jlisti;
@@ -497,7 +497,7 @@ void controladm1qn3_core(FemModel* femmodel){/*{{{*/
 	mystruct.N        = num_cost_functions+1;
 	mystruct.Jlist    = xNewZeroInit<IssmPDouble>(mystruct.M*mystruct.N);	
 	mystruct.i        = xNewZeroInit<int>(1);
-	mystruct.imin     = xNewZeroInit<int>(1);
+	mystruct.imin     = xNewZeroInit<int>(1);	
 	mystruct.Jmin     = xNewZeroInit<double>(1);
 	*(mystruct.Jmin)  = 1e+50;
 	mystruct.Xmin     = xNewZeroInit<double>(n);
@@ -539,19 +539,31 @@ void controladm1qn3_core(FemModel* femmodel){/*{{{*/
 	GetPassiveVectorFromControlInputsx(&XL,NULL,femmodel->elements,femmodel->nodes,femmodel->vertices,femmodel->loads,femmodel->materials,femmodel->parameters,"lowerbound");
 	GetPassiveVectorFromControlInputsx(&XU,NULL,femmodel->elements,femmodel->nodes,femmodel->vertices,femmodel->loads,femmodel->materials,femmodel->parameters,"upperbound");
 
+	/* recover control fields with minimum cost function*/
+	double *Xmin = NULL;
+	double *Gmin = NULL;
+	if ((*mystruct.imin) + 1 == maxiter){
+	  Xmin = X;
+	  Gmin = G;
+	}
+	else{
+	  Xmin = mystruct.Xmin;
+	  Gmin = mystruct.Gmin;
+	}
+	
 	offset = 0;
 	for (int c=0;c<num_controls;c++){
 	  for(int i=0;i<M[c]*N[c];i++){
 	    int index = offset+i;
-	    mystruct.Xmin[index] = mystruct.Xmin[index]*scaling_factors[c];
-	    if(mystruct.Xmin[index]>XU[index]) mystruct.Xmin[index]=XU[index];
-	    if(mystruct.Xmin[index]<XL[index]) mystruct.Xmin[index]=XL[index];
+	    Xmin[index] = Xmin[index]*scaling_factors[c];
+	    if(Xmin[index]>XU[index]) Xmin[index]=XU[index];
+	    if(Xmin[index]<XL[index]) Xmin[index]=XL[index];
 	  }
 	  offset += M[c]*N[c];
 	}
 
-	ControlInputSetGradientx(femmodel->elements,femmodel->nodes,femmodel->vertices,femmodel->loads,femmodel->materials,femmodel->parameters,reCast<IssmDouble*>(mystruct.Gmin));
-	SetControlInputsFromVectorx(femmodel, mystruct.Xmin);
+	ControlInputSetGradientx(femmodel->elements,femmodel->nodes,femmodel->vertices,femmodel->loads,femmodel->materials,femmodel->parameters,reCast<IssmDouble*>(Gmin));
+	SetControlInputsFromVectorx(femmodel, Xmin);
 
 	
 	if (solution_type == TransientSolutionEnum){
@@ -563,8 +575,8 @@ void controladm1qn3_core(FemModel* femmodel){/*{{{*/
 		for(int i=0;i<num_controls;i++){
 
 			/*Disect results*/
-		        GenericExternalResult<IssmPDouble*>* G_output = new GenericExternalResult<IssmPDouble*>(femmodel->results->Size()+1,Gradient1Enum+i,&mystruct.Gmin[offset],N[i],M[i]);
-			GenericExternalResult<IssmPDouble*>* X_output = new GenericExternalResult<IssmPDouble*>(femmodel->results->Size()+1,control_enum[i],&mystruct.Xmin[offset],N[i],M[i]);
+		        GenericExternalResult<IssmPDouble*>* G_output = new GenericExternalResult<IssmPDouble*>(femmodel->results->Size()+1,Gradient1Enum+i,&Gmin[offset],N[i],M[i]);
+			GenericExternalResult<IssmPDouble*>* X_output = new GenericExternalResult<IssmPDouble*>(femmodel->results->Size()+1,control_enum[i],&Xmin[offset],N[i],M[i]);
 
 			/*transpose for consistency with MATLAB's formating*/
 			G_output->Transpose();

--- a/src/c/cores/controladm1qn3_core.cpp
+++ b/src/c/cores/controladm1qn3_core.cpp
@@ -2,7 +2,6 @@
  * \brief: core of the control solution
  */
 #include <ctime>
-#include <limits>
 #include <config.h>
 #include "./cores.h"
 #include "../toolkits/toolkits.h"
@@ -499,7 +498,7 @@ void controladm1qn3_core(FemModel* femmodel){/*{{{*/
 	mystruct.i        = xNewZeroInit<int>(1);
 	mystruct.imin     = xNewZeroInit<int>(1);
 	mystruct.Jmin     = xNewZeroInit<double>(1);
-	*(mystruct.Jmin)  = std::numeric_limits<double>::infinity();
+	*(mystruct.Jmin)  = 1e+50;
 	mystruct.Xmin     = xNewZeroInit<IssmDouble>(n);
 	mystruct.Gmin     = xNewZeroInit<IssmDouble>(n);
 	/*Initialize Gradient and cost function of M1QN3*/

--- a/src/c/cores/controladm1qn3_core.cpp
+++ b/src/c/cores/controladm1qn3_core.cpp
@@ -2,6 +2,7 @@
  * \brief: core of the control solution
  */
 #include <ctime>
+#include <limits>
 #include <config.h>
 #include "./cores.h"
 #include "../toolkits/toolkits.h"
@@ -35,6 +36,9 @@ typedef struct{
 	int          M;
 	int          N;
 	int*         i;
+	int*         imin;
+	double*      Jmin;
+	Issmdouble*  Xmin;
 } m1qn3_struct;
 /*}}}*/
 
@@ -152,12 +156,14 @@ void simul_ad(long* indic,long* n,double* X,double* pf,double* G,long izs[1],flo
 	/*we need to make sure we do not modify femmodel at each iteration, make a copy*/
 	femmodel = input_struct->femmodel->copy();
 
-	IssmPDouble*  Jlist  = input_struct->Jlist;
-	int           JlistM = input_struct->M;
-	int           JlistN = input_struct->N;
-	int*          Jlisti = input_struct->i;
-	int           intn   = (int)*n;
-
+	IssmPDouble*  Jlist     = input_struct->Jlist;
+	int           JlistM    = input_struct->M;
+	int           JlistN    = input_struct->N;
+	int*          Jlisti    = input_struct->i;
+	int*          Jlistimin = input_struct->imin;
+	double*       Jmin      = input_struct->Jmin;
+	IssmDouble*   Xmin      = input_struct->Xmin;	
+	int           intn   = (int)*n;	
 	/*Recover some parameters*/
 	double *scaling_factors = NULL;
 	int    *M = NULL;
@@ -256,6 +262,13 @@ void simul_ad(long* indic,long* n,double* X,double* pf,double* G,long izs[1],flo
 			J+=output_value;
 		}
 
+		/* save control field and iteration if the minimum so far */
+		if (J < *Jmin){
+		  *Jmin = J;
+		  *Jlistimin = *Jlisti;
+		  *Xmin = aX;
+		}		
+		
 		#if defined(_HAVE_CODIPACK_)
 		// TODO: Registration of output values is more fine grained for ADOL-c.
 		codi_global.registerOutput(J);
@@ -430,7 +443,7 @@ void controladm1qn3_core(FemModel* femmodel){/*{{{*/
 	femmodel->parameters->FindParam(&control_enum,NULL,InversionControlParametersEnum);
 	femmodel->parameters->SetParam(false,SaveResultsEnum);
 	femmodel->parameters->FindParam(&N,NULL,ControlInputSizeNEnum);
-   femmodel->parameters->FindParam(&M,NULL,ControlInputSizeMEnum);
+	femmodel->parameters->FindParam(&M,NULL,ControlInputSizeMEnum);
 
 	/*Initialize M1QN3 parameters*/
 	if(VerboseControl())_printf0_("   Initialize M1QN3 parameters\n");
@@ -479,8 +492,12 @@ void controladm1qn3_core(FemModel* femmodel){/*{{{*/
 	mystruct.femmodel = femmodel;
 	mystruct.M        = maxiter;
 	mystruct.N        = num_cost_functions+1;
-	mystruct.Jlist    = xNewZeroInit<IssmPDouble>(mystruct.M*mystruct.N);
+	mystruct.Jlist    = xNewZeroInit<IssmPDouble>(mystruct.M*mystruct.N);	
 	mystruct.i        = xNewZeroInit<int>(1);
+	mystruct.imin     = xNewZeroInit<int>(1);
+	mystruct.Jmin     = xNewZeroInit<int>(1);
+	*(mystruct.Jmin)  = std::numeric_limits<double>::infinity();
+	mystruct.Xmin     = xNewZeroInit<IssmDouble>(nint);
 	/*Initialize Gradient and cost function of M1QN3*/
 	indic = 4; /*gradient required*/
 	simul_ad(&indic,&n,X,&f,G,izs,rzs,(void*)&mystruct);
@@ -509,23 +526,27 @@ void controladm1qn3_core(FemModel* femmodel){/*{{{*/
 		case 7:  _printf0_(": <g,d> > 0  or  <y,s> <0\n"); break;
 		default: _printf0_(": Unknown end condition\n");
 	}
-
+	_printf0_("   Cost function minimum occured on iteration "<<int(mystruct.imin));
+	
 	/*Constrain solution vector*/
 	double  *XL = NULL;
 	double  *XU = NULL;
 	GetPassiveVectorFromControlInputsx(&XL,NULL,femmodel->elements,femmodel->nodes,femmodel->vertices,femmodel->loads,femmodel->materials,femmodel->parameters,"lowerbound");
 	GetPassiveVectorFromControlInputsx(&XU,NULL,femmodel->elements,femmodel->nodes,femmodel->vertices,femmodel->loads,femmodel->materials,femmodel->parameters,"upperbound");
 
-   offset = 0;
-   for (int c=0;c<num_controls;c++){
-      for(int i=0;i<M[c]*N[c];i++){
-         int index = offset+i;
-         X[index] = X[index]*scaling_factors[c];
-         if(X[index]>XU[index]) X[index]=XU[index];
-         if(X[index]<XL[index]) X[index]=XL[index];
-      }
-      offset += M[c]*N[c];
-   }
+	/* retrive controls corresponding to minimum cost function value */
+	X = mystruct.Xmin;
+	
+	offset = 0;
+	for (int c=0;c<num_controls;c++){
+	  for(int i=0;i<M[c]*N[c];i++){
+	    int index = offset+i;
+	    X[index] = X[index]*scaling_factors[c];
+	    if(X[index]>XU[index]) X[index]=XU[index];
+	    if(X[index]<XL[index]) X[index]=XL[index];
+	  }
+	  offset += M[c]*N[c];
+	}
 
 	/*Set X as our new control*/
 	IssmDouble* aX=xNew<IssmDouble>(intn);

--- a/src/c/cores/controladm1qn3_core.cpp
+++ b/src/c/cores/controladm1qn3_core.cpp
@@ -169,7 +169,7 @@ void simul_ad(long* indic,long* n,double* X,double* pf,double* G,long izs[1],flo
 	int    *N = NULL;
 	int    *control_enum    = NULL;
 	int     checkpoint_frequency;
-	IssmDouble   J = 0.;
+
 	femmodel->parameters->FindParam(&num_responses,InversionNumCostFunctionsEnum);
 	femmodel->parameters->FindParam(&num_controls,InversionNumControlParametersEnum);
 	femmodel->parameters->FindParamAndMakePassive(&scaling_factors,NULL,InversionControlScalingFactorsEnum);
@@ -245,6 +245,7 @@ void simul_ad(long* indic,long* n,double* X,double* pf,double* G,long izs[1],flo
 
 		/*Go through our dependent variables, and compute the response:*/
 		dependents=xNew<IssmPDouble>(num_dependents);
+		IssmDouble   J = 0.;
 		int i=-1;
 		for(Object* & object:dependent_objects->objects){
 			i++;
@@ -397,8 +398,8 @@ void simul_ad(long* indic,long* n,double* X,double* pf,double* G,long izs[1],flo
 	_assert_(!xIsInf(Gnorm));
 
 	/* save control field and iteration if this is the minimum so far*/
-	if (J < *Jmin){
-	  *Jmin = reCast<double>(J);
+	if (*pf < *Jmin){
+	  *Jmin = *pf;
 	  *Jlistimin = *Jlisti;
 	  for (int i = 0; i < intn; i++){
 	    input_struct->Xmin[i] = X[i];

--- a/src/c/cores/controladm1qn3_core.cpp
+++ b/src/c/cores/controladm1qn3_core.cpp
@@ -37,8 +37,8 @@ typedef struct{
 	int*         i;
 	int*         imin;
 	double*      Jmin;
-	IssmDouble*  Xmin;
-	IssmDouble*  Gmin;
+	double*  Xmin;
+	double*  Gmin;
 } m1qn3_struct;
 /*}}}*/
 
@@ -162,15 +162,14 @@ void simul_ad(long* indic,long* n,double* X,double* pf,double* G,long izs[1],flo
 	int*          Jlisti    = input_struct->i;
 	int*          Jlistimin = input_struct->imin;
 	double*       Jmin      = input_struct->Jmin;
-	IssmDouble*   Xmin      = input_struct->Xmin;
-	IssmDouble*   Gmin      = input_struct->Gmin;	
-	int           intn   = (int)*n;	
+	int           intn      = (int)*n;	
 	/*Recover some parameters*/
 	double *scaling_factors = NULL;
 	int    *M = NULL;
 	int    *N = NULL;
 	int    *control_enum    = NULL;
 	int     checkpoint_frequency;
+	IssmDouble   J = 0.;
 	femmodel->parameters->FindParam(&num_responses,InversionNumCostFunctionsEnum);
 	femmodel->parameters->FindParam(&num_controls,InversionNumControlParametersEnum);
 	femmodel->parameters->FindParamAndMakePassive(&scaling_factors,NULL,InversionControlScalingFactorsEnum);
@@ -241,7 +240,6 @@ void simul_ad(long* indic,long* n,double* X,double* pf,double* G,long izs[1],flo
 		/*Get Dependents*/
 		int          num_dependents;
 		IssmPDouble *dependents;
-		IssmDouble   J = 0.;
 		DataSet     *dependent_objects = ((DataSetParam*)femmodel->parameters->FindParamObject(AutodiffDependentObjectsEnum))->value;
 		femmodel->parameters->FindParam(&num_dependents,AutodiffNumDependentsEnum);
 
@@ -263,13 +261,6 @@ void simul_ad(long* indic,long* n,double* X,double* pf,double* G,long izs[1],flo
 			J+=output_value;
 		}
 
-		/* save control field and iteration if the minimum so far */
-		if (J < *Jmin){
-		  *Jmin = reCast<double>(J);
-		  *Jlistimin = *Jlisti;
-		  Xmin = reCast<IssmDouble*>(aX);
-		  Gmin = reCast<IssmDouble*>(G);
-		}		
 		
 		#if defined(_HAVE_CODIPACK_)
 		// TODO: Registration of output values is more fine grained for ADOL-c.
@@ -405,6 +396,16 @@ void simul_ad(long* indic,long* n,double* X,double* pf,double* G,long izs[1],flo
 	_assert_(!xIsNan(Gnorm));
 	_assert_(!xIsInf(Gnorm));
 
+	/* save control field and iteration if the minimum so far */
+	if (J < *Jmin){
+	  *Jmin = reCast<double>(J);
+	  *Jlistimin = *Jlisti;
+	  for (int i = 0; i < intn; i++){
+	    input_struct->Xmin[i] = X[i];
+	    input_struct->Gmin[i] = G[i];
+	  }
+	}		
+	
 	/*Print info*/
 	InversionStatsIter( (*Jlisti)+1, *pf, reCast<double>(Gnorm), &Jlist[(*Jlisti)*JlistN], num_responses);
 
@@ -499,8 +500,8 @@ void controladm1qn3_core(FemModel* femmodel){/*{{{*/
 	mystruct.imin     = xNewZeroInit<int>(1);
 	mystruct.Jmin     = xNewZeroInit<double>(1);
 	*(mystruct.Jmin)  = 1e+50;
-	mystruct.Xmin     = xNewZeroInit<IssmDouble>(n);
-	mystruct.Gmin     = xNewZeroInit<IssmDouble>(n);
+	mystruct.Xmin     = xNewZeroInit<double>(n);
+	mystruct.Gmin     = xNewZeroInit<double>(n);
 	/*Initialize Gradient and cost function of M1QN3*/
 	indic = 4; /*gradient required*/
 	simul_ad(&indic,&n,X,&f,G,izs,rzs,(void*)&mystruct);
@@ -529,7 +530,8 @@ void controladm1qn3_core(FemModel* femmodel){/*{{{*/
 		case 7:  _printf0_(": <g,d> > 0  or  <y,s> <0\n"); break;
 		default: _printf0_(": Unknown end condition\n");
 	}
-	_printf0_("   Cost function minimum occured on iteration "<<int(*mystruct.imin));
+	
+	_printf0_("   Cost function minimum occured on iteration "<<int((*mystruct.imin) + 1) << "\n");
 	
 	/*Constrain solution vector*/
 	double  *XL = NULL;
@@ -537,21 +539,20 @@ void controladm1qn3_core(FemModel* femmodel){/*{{{*/
 	GetPassiveVectorFromControlInputsx(&XL,NULL,femmodel->elements,femmodel->nodes,femmodel->vertices,femmodel->loads,femmodel->materials,femmodel->parameters,"lowerbound");
 	GetPassiveVectorFromControlInputsx(&XU,NULL,femmodel->elements,femmodel->nodes,femmodel->vertices,femmodel->loads,femmodel->materials,femmodel->parameters,"upperbound");
 
-	IssmDouble *Xmin = mystruct.Xmin;
 	offset = 0;
 	for (int c=0;c<num_controls;c++){
 	  for(int i=0;i<M[c]*N[c];i++){
 	    int index = offset+i;
-	    Xmin[index] = Xmin[index]*scaling_factors[c];
-	    if(Xmin[index]>XU[index]) Xmin[index]=XU[index];
-	    if(Xmin[index]<XL[index]) Xmin[index]=XL[index];
+	    mystruct.Xmin[index] = mystruct.Xmin[index]*scaling_factors[c];
+	    if(mystruct.Xmin[index]>XU[index]) mystruct.Xmin[index]=XU[index];
+	    if(mystruct.Xmin[index]<XL[index]) mystruct.Xmin[index]=XL[index];
 	  }
 	  offset += M[c]*N[c];
 	}
 
-	ControlInputSetGradientx(femmodel->elements,femmodel->nodes,femmodel->vertices,femmodel->loads,femmodel->materials,femmodel->parameters,mystruct.Gmin);
-	SetControlInputsFromVectorx(femmodel, Xmin);
-	xDelete(Xmin);
+	ControlInputSetGradientx(femmodel->elements,femmodel->nodes,femmodel->vertices,femmodel->loads,femmodel->materials,femmodel->parameters,reCast<IssmDouble*>(mystruct.Gmin));
+	SetControlInputsFromVectorx(femmodel, mystruct.Xmin);
+
 	
 	if (solution_type == TransientSolutionEnum){
 		int step = 1;
@@ -562,8 +563,8 @@ void controladm1qn3_core(FemModel* femmodel){/*{{{*/
 		for(int i=0;i<num_controls;i++){
 
 			/*Disect results*/
-			GenericExternalResult<IssmPDouble*>* G_output = new GenericExternalResult<IssmPDouble*>(femmodel->results->Size()+1,Gradient1Enum+i,&G[offset],N[i],M[i]);
-			GenericExternalResult<IssmPDouble*>* X_output = new GenericExternalResult<IssmPDouble*>(femmodel->results->Size()+1,control_enum[i],&X[offset],N[i],M[i]);
+		        GenericExternalResult<IssmPDouble*>* G_output = new GenericExternalResult<IssmPDouble*>(femmodel->results->Size()+1,Gradient1Enum+i,&mystruct.Gmin[offset],N[i],M[i]);
+			GenericExternalResult<IssmPDouble*>* X_output = new GenericExternalResult<IssmPDouble*>(femmodel->results->Size()+1,control_enum[i],&mystruct.Xmin[offset],N[i],M[i]);
 
 			/*transpose for consistency with MATLAB's formating*/
 			G_output->Transpose();
@@ -603,6 +604,10 @@ void controladm1qn3_core(FemModel* femmodel){/*{{{*/
 	xDelete<double>(scaling_factors);
 	xDelete<IssmPDouble>(mystruct.Jlist);
 	xDelete<int>(mystruct.i);
+	xDelete<int>(mystruct.imin);
+	xDelete<double>(mystruct.Jmin);
+	xDelete<double>(mystruct.Xmin);
+	xDelete<double>(mystruct.Gmin);
 	xDelete<int>(control_enum);
 	xDelete<int>(M);
 	xDelete<int>(N);


### PR DESCRIPTION
Have not tested, but does compile.

This is to keep track of the cost function minimum in case it doesn't occur on the last iteration.

For example we want to avoid this:

<img width="1291" height="724" alt="Screenshot 2026-04-30 at 9 36 51 AM" src="https://github.com/user-attachments/assets/d9e979be-1396-4757-918e-77eef228402b" />
