### PR TITLE
issmversion.py: Fix so docstring is correct and prints version

### DIFF
--- a/src/m/dev/issmversion.py
+++ b/src/m/dev/issmversion.py
@@ -8,9 +8,13 @@ def issmversion():
             issmversion()
     """
 
-print(' ')
-print((IssmConfig('PACKAGE_NAME')[0] + ' Version ' + IssmConfig('PACKAGE_VERSION')[0]))
-print(('(website: ' + IssmConfig('PACKAGE_URL')[0] + ' contact: ' + IssmConfig('PACKAGE_BUGREPORT')[0] + ')'))
-print(' ')
-print(('Build date: ' + IssmConfig('PACKAGE_BUILD_DATE')[0]))
-print('Copyright (c) 2009-2026 California Institute of Technology (3-Clause BSD License)')
+    print(' ')
+    print((IssmConfig('PACKAGE_NAME')[0] + ' Version ' + IssmConfig('PACKAGE_VERSION')[0]))
+    print(('(website: ' + IssmConfig('PACKAGE_URL')[0] + ' contact: ' + IssmConfig('PACKAGE_BUGREPORT')[0] + ')'))
+    print(' ')
+    print(('Build date: ' + IssmConfig('PACKAGE_BUILD_DATE')[0]))
+    print('Copyright (c) 2009-2026 California Institute of Technology (3-Clause BSD License)')
+
+
+# print 1x when imported
+issmversion()


### PR DESCRIPTION
Calling `issmversion()` doesn't print anything even though docstring implies it will. This fixes that. This is still a bit confusing if running this in notebooks with persistent sessions, because the 2nd time it's imported nothing is printed and the previous version ouptut is removed, implying your environment is not working correctly. A better implementation might not print anything when imported, and documentation could be updated from 

```
from issmversion import issmversion
```

to 
```
from issmversion import issmversion
issmversion()
```

Which would behave the same if run 1x or 2x in a persistent session.