### PR TITLE
export_netCDF.py: Add overwrite keyword

### DIFF
--- a/src/m/netcdf/OLD/export_netCDF.py
+++ b/src/m/netcdf/OLD/export_netCDF.py
@@ -66,10 +66,10 @@ class ResTable:
             return np.squeeze(np.asarray(self.data))
 
 
-def export_netCDF(md, filename):  # {{{
+def export_netCDF(md, filename, overwrite=False):  # {{{
     #verbosity of the code, 0 is no messages, 5 is chatty
     verbose = 0
-    if path.exists(filename):
+    if path.exists(filename) and (overwrite == False):
         print('File {} already exists'.format(filename))
         newname = input('Give a new name or "delete" to replace: ')
         if newname == 'delete':


### PR DESCRIPTION
Added `overwrite=False` keyword to `export_netCDF' function. No change to default behavior. 

Setting to `True` and adding this to calls to the function (e.g., `export_netCDF(md, './Greenland.Mesh_generation.nc', overwrite=True)`) skips the interactive request asking to rename file or make the user type `delete` to continue.